### PR TITLE
Add support for Docker 1.13

### DIFF
--- a/posh-docker/posh-docker.psm1
+++ b/posh-docker/posh-docker.psm1
@@ -86,7 +86,7 @@ $completion_Docker = {
         
         docker --help | ForEach-Object {
             Write-Output $_
-            if ($_ -match "^    (\w+)\s+(.+)")
+            if ($_ -match "^\s{2,3}(\w+)\s+(.+)")
             {
                 $global:DockerCompletion["commands"][$Matches[1]] = @{}
                 


### PR DESCRIPTION
Fixes #15. Apparently commands are now prefixed by 2 spaces instead of 3. This change supports both.